### PR TITLE
s/Collaboratory/DREAM Lab/g

### DIFF
--- a/community/instructors.md
+++ b/community/instructors.md
@@ -8,7 +8,7 @@ title: UCSB Library Carpentry Community
 
 # Carpentry Volunteering
 
-Running a workshop is done through the group effort of people in teaching and/or assisting roles. The <b>lead instructor</b> directs the curriculum development and establishes learning goals of the workshop. They also teach segments of the workshop to a live audience. For certification to be a lead instructor, read onto "Becoming a Certified Carpentry Instructor". Lead instructors are not expected to teach a whole workshop themselves: through <b>co-instructing</b>, others may teach some workshop segments and support any discussion initiated by the lead instructor. Because workshops depend on live-coding and hands-on demos, <b>helpers</b> are needed to provide immediate help to workshop attendees. Helpers also assist in the workings of workshops; such as hosting remote/in-person meetings, taking lesson notes, and answering questions from attendees. For all stages of workshop development; lead instructors, instructors, and helpers are supported by staff at the Interdisciplinary Research Collaboratory.
+Running a workshop is done through the group effort of people in teaching and/or assisting roles. The <b>lead instructor</b> directs the curriculum development and establishes learning goals of the workshop. They also teach segments of the workshop to a live audience. For certification to be a lead instructor, read onto "Becoming a Certified Carpentry Instructor". Lead instructors are not expected to teach a whole workshop themselves: through <b>co-instructing</b>, others may teach some workshop segments and support any discussion initiated by the lead instructor. Because workshops depend on live-coding and hands-on demos, <b>helpers</b> are needed to provide immediate help to workshop attendees. Helpers also assist in the workings of workshops; such as hosting remote/in-person meetings, taking lesson notes, and answering questions from attendees. For all stages of workshop development; lead instructors, instructors, and helpers are supported by staff in DREAM Lab (formerly, Interdisciplinary Research Collaboratory).
 
 # Becoming a Certified Carpentry Instructor
 
@@ -23,7 +23,7 @@ people through the Instructor certification process, which includes:
 * A practical teaching demonstration.
 
 Once you are a certified Instructor, you are able to self-organize Carpentry
-Workshops on your own. The Library's Interdisciplinary Research Collaboratory
+Workshops on your own. The Library's DREAM Lab
 also organizes and hosts about three workshops every quarter. If you participate in an upcoming instructor
 training, we expect some things from you in return:
 * Complete the certification process (there are 3 post-training tasks)

--- a/community/workshops.md
+++ b/community/workshops.md
@@ -1,5 +1,5 @@
 ## UCSB Carpentries
-The Library's *Interdisciplinary Research Collaboratory* organizes workshops on 
+The Library's *DREAM Lab* organizes workshops on
 behalf of campus constituents. * We can teach and host a variety of the curriculum 
 from Software, Data, and Library Carpentries, and are able to secure lead 
 Instructors for any lesson in the Carpentries curricula.

--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ Email [rds@library.ucsb.edu](mailto:rds@library.ucsb.edu) for more information.
 -->
 
 ## About Us
-**[The Carpentries](https://carpentries.org/)** project is an international organization of volunteers teaching foundational coding and data science skills to researchers. Carpentry Workshops at UCSB are supported and organized by our stellar volunteers and the Interdisciplinary Research Collaboratory at the UCSB Library.
+**[The Carpentries](https://carpentries.org/)** project is an international organization of volunteers teaching foundational coding and data science skills to researchers. Carpentry Workshops at UCSB are supported and organized by our stellar volunteers and the DREAM Lab (formerly, Interdisciplinary Research Collaboratory) at UCSB Library.
 <!---
 Uncomment after the page is done.
 [We have a few policies.](community/workshops)
@@ -31,7 +31,7 @@ Uncomment after the page is done.
 
 We offer guided and hands-on workshops to researchers, including undergraduate, staff, graduate students, post-docs, and faculty. These teachings focus on beginner-level research computing, data literacy, and information management. Resources that persist outside of workshops is our community of data research and programming "carpenters," and the teaching material of [previous workshops](https://ucsbcarpentry.github.io/past-workshops).
 
-If you want to stay in the loop for future workshops, you can join our Carpentry mailing list with an @ucsb.edu email address and/or join our slack channel. If you do not have an @ucsb.edu email address, please email the Collaboratory directly so we can add you.
+If you want to stay in the loop for future workshops, you can join our Carpentry mailing list with an @ucsb.edu email address and/or join our slack channel. If you do not have an @ucsb.edu email address, please email the DREAM Lab directly so we can add you.
 
 For a few of us, teaching Carpentry workshops is part of our job descriptions, but most are volunteers from around campus and the global Carpentries community- including researchers, post-docs, graduate students, faculty and staff. If you would like to get involved with putting on these workshops, please email us at **library-collaboratory@ucsb.edu** or visit our **[Instructors Page](https://ucsbcarpentry.github.io/community/instructors)**.
 
@@ -39,4 +39,4 @@ For a few of us, teaching Carpentry workshops is part of our job descriptions, b
 <br>
 *Your UCSB Carpentry Team*
 
-P.S. [See the Collaboratory calendar page for more events!](https://www.library.ucsb.edu/events-exhibitions?location=All&series=1218)
+P.S. [See the DREAM Lab calendar page for more events!](https://www.library.ucsb.edu/events-exhibitions?location=All&series=1218)


### PR DESCRIPTION
This replaces references to collaboratory with "DREAM Lab"