### PR TITLE
turn off uglyURLs and set page aliases for old content

### DIFF
--- a/content/community/carpentries-community.md
+++ b/content/community/carpentries-community.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/community/carpentries-community.html"
 title: UCSB Library Carpentry Community
 ---
 

--- a/content/community/instructors.md
+++ b/content/community/instructors.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/community/instructors.html"
 title: UCSB Library Carpentry Community
 hide_title: true
 ---

--- a/content/community/workshops.md
+++ b/content/community/workshops.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/community/workshops.html"
 title: UCSB Carpentries Workshop Practices
 ---
 

--- a/content/meeting/2022-09-26-community-meeting.md
+++ b/content/meeting/2022-09-26-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2022/09/26/community-meeting.html"
 date: 2022-09-26
 slug: community-meeting
 title: "Fall Kickoff Meeting"

--- a/content/meeting/2022-10-27-community-meeting.md
+++ b/content/meeting/2022-10-27-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2022/10/27/community-meeting.html"
 date: 2022-10-27
 slug: community-meeting
 title: "October Community Meeting"

--- a/content/meeting/2022-11-29-community-meeting.md
+++ b/content/meeting/2022-11-29-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2022/11/29/community-meeting.html"
 date: 2022-11-29
 slug: community-meeting
 title: "November Community Meeting"

--- a/content/meeting/2023-01-18-community-meeting.md
+++ b/content/meeting/2023-01-18-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2023/01/18/community-meeting.html"
 date: 2023-01-18
 slug: community-meeting
 title: "Community Meeting"

--- a/content/meeting/2023-03-02-community-meeting.md
+++ b/content/meeting/2023-03-02-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2023/03/02/community-meeting.html"
 date: 2023-03-02
 slug: community-meeting
 title: "Community Meeting"

--- a/content/meeting/2023-04-25-community-meeting.md
+++ b/content/meeting/2023-04-25-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2023/04/25/community-meeting.html"
 date: 2023-04-25
 slug: community-meeting
 title: "Community Meeting"

--- a/content/meeting/2023-10-12-community-meeting.md
+++ b/content/meeting/2023-10-12-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2023/10/12/community-meeting.html"
 date: 2023-10-12
 slug: community-meeting
 title: "Community Meeting"

--- a/content/meeting/2024-01-18-community-meeting.md
+++ b/content/meeting/2024-01-18-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2024/01/18/community-meeting.html"
 date: 2024-01-18
 slug: community-meeting
 title: "Community Meeting"

--- a/content/meeting/2024-04-17-community_meeting.md
+++ b/content/meeting/2024-04-17-community_meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2024/04/17/community_meeting.html"
 date: 2024-04-17
 slug: community_meeting
 title: "Community Meeting"

--- a/content/meeting/2024-11-13-community-meeting.md
+++ b/content/meeting/2024-11-13-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2024/11/13/community-meeting.html"
 date: 2024-11-13
 slug: community-meeting
 title: "Community Meeting"

--- a/content/meeting/2025-02-26-community-meeting.md
+++ b/content/meeting/2025-02-26-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2025/02/26/community-meeting.html"
 date: 2025-02-26
 slug: community-meeting
 title: "Community Meeting"

--- a/content/meeting/2025-10-20-community-meeting.md
+++ b/content/meeting/2025-10-20-community-meeting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/meeting/2025/10/20/community-meeting.html"
 date: 2025-10-20
 slug: community-meeting
 title: "Community Meeting"

--- a/content/workshop/2023-10-23-ucsb-git.md
+++ b/content/workshop/2023-10-23-ucsb-git.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2023/10/23/ucsb-git.html"
 date: 2023-10-23
 slug: ucsb-git
 title: "Introduction to Version Control with Git"

--- a/content/workshop/2023-11-13-ucsb-python.md
+++ b/content/workshop/2023-11-13-ucsb-python.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2023/11/13/ucsb-python.html"
 date: 2023-11-13
 slug: ucsb-python
 title: "Data Analysis and Visualization in Python"

--- a/content/workshop/2023-12-11-ucsb-quarto.md
+++ b/content/workshop/2023-12-11-ucsb-quarto.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2023/12/11/ucsb-quarto.html"
 date: 2023-12-11
 slug: ucsb-quarto
 title: "Reproducible Publications with Quarto"

--- a/content/workshop/2024-01-30-ucsb-git.md
+++ b/content/workshop/2024-01-30-ucsb-git.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/01/30/ucsb-git.html"
 date: 2024-01-30
 slug: ucsb-git
 title: "Version Control with Git"

--- a/content/workshop/2024-02-27-ucsb-webscraping.md
+++ b/content/workshop/2024-02-27-ucsb-webscraping.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/02/27/ucsb-webscraping.html"
 date: 2024-02-27
 slug: ucsb-webscraping
 title: "Introduction to Web Scraping"

--- a/content/workshop/2024-05-01-ucsb-r.md
+++ b/content/workshop/2024-05-01-ucsb-r.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/05/01/ucsb-r.html"
 date: 2024-05-01
 slug: ucsb-r
 title: "Introduction to Data Analysis with R for Social Science"

--- a/content/workshop/2024-06-04-ucsb-containers.md
+++ b/content/workshop/2024-06-04-ucsb-containers.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/06/04/ucsb-containers.html"
 date: 2024-06-04
 slug: ucsb-containers
 title: "Container-driven Reproducible Research Made Simple"

--- a/content/workshop/2024-06-10-ucsb-geospatial.md
+++ b/content/workshop/2024-06-10-ucsb-geospatial.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/06/10/ucsb-geospatial.html"
 date: 2024-06-10
 slug: ucsb-geospatial
 title: "Introduction to Geospatial Raster and Vector Data with R (Dress Rehearsal)"

--- a/content/workshop/2024-07-02-ucsb-spreadsheets.md
+++ b/content/workshop/2024-07-02-ucsb-spreadsheets.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/07/02/ucsb-spreadsheets.html"
 date: 2024-07-02
 slug: ucsb-spreadsheets
 title: "Data Organization in Spreadsheets"

--- a/content/workshop/2024-07-09-ucsb-python.md
+++ b/content/workshop/2024-07-09-ucsb-python.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/07/09/ucsb-python.html"
 date: 2024-07-09
 slug: ucsb-python
 title: "Data Analysis and Visualization in Python"

--- a/content/workshop/2024-09-05-SPNHC24.md
+++ b/content/workshop/2024-09-05-SPNHC24.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/09/05/spnhc24.html"
 date: 2024-09-05
 slug: SPNHC24
 title: "Data Carpentry: Species Interaction Data Workshop (SPNHC/TDWH registrants only)"

--- a/content/workshop/2024-09-09-UC.md
+++ b/content/workshop/2024-09-09-UC.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/09/09/uc.html"
 date: 2024-09-09
 slug: UC
 title: "2024 UC Carpentries Workshop Series (Remote)"

--- a/content/workshop/2024-10-08-ucsb-r.md
+++ b/content/workshop/2024-10-08-ucsb-r.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/10/08/ucsb-r.html"
 date: 2024-10-08
 slug: ucsb-r
 title: "Introduction to Data Analysis with R"

--- a/content/workshop/2024-10-22-ucsb-git.md
+++ b/content/workshop/2024-10-22-ucsb-git.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/10/22/ucsb-git.html"
 date: 2024-10-22
 slug: ucsb-git
 title: "Version Control with Git and GitHub"

--- a/content/workshop/2024-11-05-ucsb-webscraping.md
+++ b/content/workshop/2024-11-05-ucsb-webscraping.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/11/05/ucsb-webscraping.html"
 date: 2024-11-05
 slug: ucsb-webscraping
 title: "Web Scraping with Python"

--- a/content/workshop/2024-11-12-ucsb-qualdatanalysis.md
+++ b/content/workshop/2024-11-12-ucsb-qualdatanalysis.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2024/11/12/ucsb-qualdatanalysis.html"
 date: 2024-11-12
 slug: ucsb-qualdatanalysis
 title: "Handling and Sharing Qualitative Data Responsibly and Effectively"

--- a/content/workshop/2025-01-14-ucsb-python.md
+++ b/content/workshop/2025-01-14-ucsb-python.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/01/14/ucsb-python.html"
 date: 2025-01-14
 slug: ucsb-python
 title: "Introduction to Data Analysis with Python"

--- a/content/workshop/2025-01-23-ucsb-geospatial.md
+++ b/content/workshop/2025-01-23-ucsb-geospatial.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/01/23/ucsb-geospatial.html"
 date: 2025-01-23
 slug: ucsb-geospatial
 title: "Working with Geospatial Data in R"

--- a/content/workshop/2025-02-03-ucsb-computing.md
+++ b/content/workshop/2025-02-03-ucsb-computing.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/02/03/ucsb-computing.html"
 date: 2025-02-03
 slug: ucsb-computing
 title: "Research Computing - What to do when your work gets too big for your laptop"

--- a/content/workshop/2025-02-05-ucsb-containers.md
+++ b/content/workshop/2025-02-05-ucsb-containers.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/02/05/ucsb-containers.html"
 date: 2025-02-05
 slug: ucsb-containers
 title: "Container-driven Reproducible Research Made Simple"

--- a/content/workshop/2025-02-18-ucsb-intermediater.md
+++ b/content/workshop/2025-02-18-ucsb-intermediater.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/02/18/ucsb-intermediater.html"
 date: 2025-02-18
 slug: ucsb-intermediater
 title: "Intermediate R"

--- a/content/workshop/2025-02-25-ucsb-ml.md
+++ b/content/workshop/2025-02-25-ucsb-ml.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/02/25/ucsb-ml.html"
 date: 2025-02-25
 slug: ucsb-ml
 title: "Introduction to Machine Learning in Python"

--- a/content/workshop/2025-04-10-ucsb-shell.md
+++ b/content/workshop/2025-04-10-ucsb-shell.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/04/10/ucsb-shell.html"
 date: 2025-04-10
 slug: ucsb-shell
 title: "Introduction to The Unix Shell"

--- a/content/workshop/2025-04-11-ucsb-shell.md
+++ b/content/workshop/2025-04-11-ucsb-shell.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/04/11/ucsb-shell.html"
 date: 2025-04-11
 slug: ucsb-shell
 title: "Introduction to The Unix Shell (Online)"

--- a/content/workshop/2025-04-14-ucsb-git.md
+++ b/content/workshop/2025-04-14-ucsb-git.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/04/14/ucsb-git.html"
 date: 2025-04-14
 slug: ucsb-git
 title: "Getting Started with Git and GitHub"

--- a/content/workshop/2025-04-16-ucsb-gitcollab.md
+++ b/content/workshop/2025-04-16-ucsb-gitcollab.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/04/16/ucsb-gitcollab.html"
 date: 2025-04-16
 slug: ucsb-gitcollab
 title: "Collaborating with Git and GitHub"

--- a/content/workshop/2025-04-29-ucsb-computing.md
+++ b/content/workshop/2025-04-29-ucsb-computing.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/04/29/ucsb-computing.html"
 date: 2025-04-29
 slug: ucsb-computing
 title: "Research Computing - What to do when your work gets too big for your laptop"

--- a/content/workshop/2025-05-01-ucsb-r.md
+++ b/content/workshop/2025-05-01-ucsb-r.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/05/01/ucsb-r.html"
 date: 2025-05-01
 slug: ucsb-r
 title: "Introduction to Data Analysis with R"

--- a/content/workshop/2025-05-21-ucsb-text.md
+++ b/content/workshop/2025-05-21-ucsb-text.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/05/21/ucsb-text.html"
 date: 2025-05-21
 slug: ucsb-text
 title: "Fundamentals of Text Analysis with Programming"

--- a/content/workshop/2025-07-08-ucsb-geospatial.md
+++ b/content/workshop/2025-07-08-ucsb-geospatial.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/07/08/ucsb-geospatial.html"
 date: 2025-07-08
 slug: ucsb-geospatial
 title: "Intro to Geospatial Raster and Vector Data with R"

--- a/content/workshop/2025-09-15-UC.md
+++ b/content/workshop/2025-09-15-UC.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/09/15/uc.html"
 date: 2025-09-15
 slug: UC
 title: "2025 UC Carpentries Workshop Series (Remote)"

--- a/content/workshop/2025-09-16-ucsb-python.md
+++ b/content/workshop/2025-09-16-ucsb-python.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/09/16/ucsb-python.html"
 date: 2025-09-16
 slug: ucsb-python
 title: "Introduction to Python for MTM Students"

--- a/content/workshop/2025-10-07-ucsb-shell.md
+++ b/content/workshop/2025-10-07-ucsb-shell.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/10/07/ucsb-shell.html"
 date: 2025-10-07
 slug: ucsb-shell
 title: "Introduction to The Unix Shell"

--- a/content/workshop/2025-10-14-ucsb-git.md
+++ b/content/workshop/2025-10-14-ucsb-git.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/10/14/ucsb-git.html"
 date: 2025-10-14
 slug: ucsb-git
 title: "Version Control with Git and GitHub"

--- a/content/workshop/2025-10-27-ucsb-computing.md
+++ b/content/workshop/2025-10-27-ucsb-computing.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/10/27/ucsb-computing.html"
 date: 2025-10-27
 slug: ucsb-computing
 title: "Research Computing - What to do when your work gets too big for your laptop"

--- a/content/workshop/2025-10-28-ucsb-python.md
+++ b/content/workshop/2025-10-28-ucsb-python.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2025/10/28/ucsb-python.html"
 date: 2025-10-28
 slug: ucsb-python
 title: "Introduction to Data Analysis with Python"

--- a/content/workshop/2026-01-05-ucsb-geospatial.md
+++ b/content/workshop/2026-01-05-ucsb-geospatial.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2026/01/05/ucsb-geospatial.html"
 date: 2026-01-05
 slug: ucsb-geospatial
 title: "Geospatial Data Carpentry for Urbanism using R"

--- a/content/workshop/2026-01-14-ucsb-r.md
+++ b/content/workshop/2026-01-14-ucsb-r.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2026/01/14/ucsb-r.html"
 date: 2026-01-14
 slug: ucsb-r
 title: "Introduction to Data Analysis with R"

--- a/content/workshop/2026-01-27-ucsb-webscraping.md
+++ b/content/workshop/2026-01-27-ucsb-webscraping.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2026/01/27/ucsb-webscraping.html"
 date: 2026-01-27
 slug: ucsb-webscraping
 title: "Web Scraping with Python"

--- a/content/workshop/2026-02-02-ucsb-ml.md
+++ b/content/workshop/2026-02-02-ucsb-ml.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2026/02/02/ucsb-ml.html"
 date: 2026-02-02
 slug: ucsb-ml
 title: "Introduction to Machine Learning in Python"

--- a/content/workshop/2026-04-07-ucsb-git.md
+++ b/content/workshop/2026-04-07-ucsb-git.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2026/04/07/ucsb-git.html"
 date: 2026-04-07
 slug: ucsb-git
 title: "Version Control with Git and GitHub"

--- a/content/workshop/2026-04-13-ucsb-python.md
+++ b/content/workshop/2026-04-13-ucsb-python.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2026/04/13/ucsb-python.html"
 date: 2026-04-13
 slug: ucsb-python
 title: "Introduction to Data Analysis with Python"

--- a/content/workshop/2026-05-04-ucsb-computing.md
+++ b/content/workshop/2026-05-04-ucsb-computing.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2026/05/04/ucsb-computing.html"
 date: 2026-05-04
 slug: ucsb-computing
 title: "Research Computing - What to do when your work gets too big for your laptop"

--- a/content/workshop/2026-05-11-uc-lc.md
+++ b/content/workshop/2026-05-11-uc-lc.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/workshop/2026/05/11/ucsb-carpentry.html"
 date: 2026-05-11
 slug: ucsb-carpentry
 title: "2026 UC Library Carpentry Workshop Series (Remote)"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -23,6 +23,3 @@ markup:
   goldmark:
     renderer:
       unsafe: true
-
-# Output URLs with .html extensions (matches Jekyll behavior)
-uglyURLs: true


### PR DESCRIPTION
This PR changes the site's URL scheme from the old Jekyll format (where pages end in `.html`) to Hugo's default format without trailing file extensions. It also adds [aliases](https://gohugo.io/content-management/front-matter/#aliases) to existing pages so that the old page links are redirected to the new URL.

Previously, we used the `uglyURLs: true` setting to preserve compatibility with the Jekyll-based URL structure. For blog posts, that URL structure doesn't work well. I want our posts to be "[leaf bundles](https://gohugo.io/content-management/page-bundles/#leaf-bundles)", so that the text and related images are all together in a post-specific folder. Unfortunately,  leaf bundles don't work with `uglyURLs: true`.

Note, `aliases` are only needed for existing content where we need to handle incoming links using the Jekyll-style URLs. Going forward, new content should *only* use Hugo-style links without an alias.